### PR TITLE
Reset on focusable element removal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "blobity",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blobity",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Fun blob cursor for any website",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/site/src/pages/index.tsx
+++ b/site/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect} from 'react';
+import React, { useEffect } from 'react';
 import './styles.css';
 import { Head } from '../components/Head';
 import { Header } from '../components/Header';

--- a/site/src/pages/index.tsx
+++ b/site/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef} from 'react';
+import React, {useEffect} from 'react';
 import './styles.css';
 import { Head } from '../components/Head';
 import { Header } from '../components/Header';
@@ -42,7 +42,6 @@ export const initiaBlobityOptions = {
 
 export default () => {
     const blobityInstance = useBlobity(initiaBlobityOptions);
-    const removableElement = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
         if (blobityInstance.current) {
@@ -50,10 +49,6 @@ export default () => {
             window.blobity = blobityInstance.current;
         }
     }, [blobityInstance]);
-
-    const removeButton = () => {
-        removableElement.current?.remove();
-    }
 
     return (
         <div>
@@ -80,11 +75,12 @@ export default () => {
                     The cursor is the heart of any interaction with the web.
                     <br /> Why not take it to the next level? 🚀
                 </Text>
-                <div ref={removableElement}>
-                    <div>
-                        <Button onClick={removeButton}>Remove me on click!</Button>
-                    </div>
-                </div>
+                <Button href="https://gmrchk.gumroad.com/l/blobity">
+                    Get Blobity
+                </Button>
+                <Button href="https://github.com/gmrchk/blobity#readme" ghost>
+                    Documentation
+                </Button>
             </Section>
             <Section id="customize">
                 <Layout>

--- a/site/src/pages/index.tsx
+++ b/site/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, {useEffect, useRef} from 'react';
 import './styles.css';
 import { Head } from '../components/Head';
 import { Header } from '../components/Header';
@@ -42,6 +42,7 @@ export const initiaBlobityOptions = {
 
 export default () => {
     const blobityInstance = useBlobity(initiaBlobityOptions);
+    const removableButton = useRef<HTMLAnchorElement>(null);
 
     useEffect(() => {
         if (blobityInstance.current) {
@@ -49,6 +50,10 @@ export default () => {
             window.blobity = blobityInstance.current;
         }
     }, [blobityInstance]);
+
+    const removeButton = () => {
+        removableButton.current?.remove();
+    }
 
     return (
         <div>
@@ -75,12 +80,7 @@ export default () => {
                     The cursor is the heart of any interaction with the web.
                     <br /> Why not take it to the next level? 🚀
                 </Text>
-                <Button href="https://gmrchk.gumroad.com/l/blobity">
-                    Get Blobity
-                </Button>
-                <Button href="https://github.com/gmrchk/blobity#readme" ghost>
-                    Documentation
-                </Button>
+                <Button ref={removableButton} onClick={removeButton}>Remove me on click!</Button>
             </Section>
             <Section id="customize">
                 <Layout>

--- a/site/src/pages/index.tsx
+++ b/site/src/pages/index.tsx
@@ -42,7 +42,7 @@ export const initiaBlobityOptions = {
 
 export default () => {
     const blobityInstance = useBlobity(initiaBlobityOptions);
-    const removableButton = useRef<HTMLAnchorElement>(null);
+    const removableElement = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
         if (blobityInstance.current) {
@@ -52,7 +52,7 @@ export default () => {
     }, [blobityInstance]);
 
     const removeButton = () => {
-        removableButton.current?.remove();
+        removableElement.current?.remove();
     }
 
     return (
@@ -80,7 +80,11 @@ export default () => {
                     The cursor is the heart of any interaction with the web.
                     <br /> Why not take it to the next level? 🚀
                 </Text>
-                <Button ref={removableButton} onClick={removeButton}>Remove me on click!</Button>
+                <div ref={removableElement}>
+                    <div>
+                        <Button onClick={removeButton}>Remove me on click!</Button>
+                    </div>
+                </div>
             </Section>
             <Section id="customize">
                 <Layout>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,11 @@
     "forceConsistentCasingInFileNames": true,
     "outDir": "lib",
     "listEmittedFiles": true,
-    "declaration": true
+    "declaration": true,
+    "downlevelIteration": true,
+    "lib": [
+      "es5", "es6", "dom", "dom.iterable"
+    ]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules/**/*"]


### PR DESCRIPTION
Fixes https://github.com/gmrchk/blobity/issues/8

When an element focused by Blobity (like button) is removed from DOM for any reason, Blobity was not properly resetting the position to the current position of the cursor. 

This PR fixes it by observing the parent DOM mutations and detecting when the focused element is being removed. Unfortunately, there is no way to observe the DOM events of the element directly, but given that the observing is done on the direct parent, this should not be a performance issue. 