### PR TITLE
fix: remove overflow visible on canvas

### DIFF
--- a/src/Blobity.ts
+++ b/src/Blobity.ts
@@ -255,7 +255,6 @@ export default class Blobity {
             pointer-events: none;
             opacity: 1;
             will-change: transform;
-            overflow: visible;
             opacity: ${this.options.opacity}; 
             z-index: ${this.options.invert ? 2147483647 : this.options.zIndex}; 
             ${this.options.invert && 'mix-blend-mode: difference'};


### PR DESCRIPTION
Since specifying `overflow: visible` on img, video and canvas tags may cause them to produce visual content outside of the element bounds and considered to be part of Deprecated API (and scheduled to be removed from Chrome), I propose to remove it.
See https://github.com/WICG/shared-element-transitions/blob/main/debugging_overflow_on_images.md.
